### PR TITLE
runafter -> runAfter

### DIFF
--- a/test/pipeline.yaml
+++ b/test/pipeline.yaml
@@ -18,7 +18,7 @@ spec:
     - name: sleep
       taskRef:
         name: sleep
-      runafter:
+      runAfter:
         - acquire-lease
       params:
         - name: duration


### PR DESCRIPTION
Small update: `runafter` changed to `runAfter`